### PR TITLE
Rename Preconditioner to PreconBuilder

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -34,7 +34,7 @@ jobs:
             arch: x64
     steps:
       - uses: actions/checkout@v4
-      - uses: julia-actions/setup-julia@v1
+      - uses: julia-actions/setup-julia@v2
         with:
           version: ${{ matrix.version }}
           arch: ${{ matrix.arch }}
@@ -51,7 +51,7 @@ jobs:
       - uses: julia-actions/julia-buildpkg@v1
       - uses: julia-actions/julia-runtest@v1
       - uses: julia-actions/julia-processcoverage@v1
-      - uses: codecov/codecov-action@v3
+      - uses: codecov/codecov-action@v4
   docs:
     name: Documentation
     runs-on: ubuntu-latest

--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -15,8 +15,8 @@ jobs:
       fail-fast: false
       matrix:
         version:
-#          - '1.9' # Replace this with the minimum Julia version that your package supports. E.g. if your package requires Julia 1.5 or higher, change this to '1.5'.
-          - '1'   # Leave this line unchanged. '1' will automatically expand to the latest stable 1.x release of Julia.
+          - lts
+          - '1'
           - 'nightly'
         os:
           - ubuntu-latest
@@ -74,4 +74,3 @@ jobs:
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           DOCUMENTER_KEY: ${{ secrets.DOCUMENTER_KEY }}
-          

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 # Changelog
 
+## v2.0, 2024-10-23
+- Rename Preconditioner to PreconBuilder, closer to the logic of the LinearSolve precs API
+
 ## v1.0, 2024-08-23
 - Support `precs` API of LinearSolve
 - Not really breaking, but transition to genuine semantig versioning
@@ -11,10 +14,10 @@
 - Require julia 1.9
 
 ## v0.3, 2024-01-15
-- LinearSolve extension, solver support  via a LinearSolveFunction 
+- LinearSolve extension, solver support  via a LinearSolveFunction
 - Change default for RLXPrecon to ILU0
 
-## v0.2, 2024-01-09 
+## v0.2, 2024-01-09
 - Finalization of API, exception handling
 
 ## v0.1, 2024-01-08

--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "AMGCLWrap"
 uuid = "4f76b812-4ba5-496d-b042-d70715554288"
 authors = ["Jürgen Fuhrmann <juergen-fuhrmann@web.de> and contributors"]
-version = "1.0.0"
+version = "2.0.0"
 
 [deps]
 AMGCL_C_jll = "e3ba5bb7-5aef-5326-9a13-9617383dcacb"

--- a/docs/src/preconditioners.md
+++ b/docs/src/preconditioners.md
@@ -2,8 +2,7 @@
 
 ```@docs
 AMGPrecon
-AMGPreconditioner
+AMGPreconBuilder
 RLXPrecon
-RLXPreconditioner
+RLXPreconBuilder
 ```
-

--- a/src/AMGCLWrap.jl
+++ b/src/AMGCLWrap.jl
@@ -18,7 +18,7 @@ include("parameters.jl")
 include("struct_api.jl")
 
 export AMGSolver, RLXSolver, AMGPrecon, RLXPrecon, blocksize_instantiated, error_state
-export AMGPreconditioner, RLXPreconditioner
+export AMGPreconBuilder, RLXPreconBuilder
 export AMGSolverAlgorithm, RLXSolverAlgorithm
 
 

--- a/src/struct_api.jl
+++ b/src/struct_api.jl
@@ -2,7 +2,7 @@
 # Docstring snippets
 
 const matrixparam="""
-                  - `sparsematrix`: `SparseArrays.AbstractSparseMatrixCSC` or `SparseMatricesCSR.SparseMatrixCSR`. 
+                  - `sparsematrix`: `SparseArrays.AbstractSparseMatrixCSC` or `SparseMatricesCSR.SparseMatrixCSR`.
                   """
 
 const stdparams = """
@@ -14,11 +14,11 @@ const amgsolverparams= """
                        - `coarsening`: One of the  [Coarsening strategies](@ref)
                        - `relax`: One of the [Relaxation strategies](@ref)
                        - `solver`: One of the [Iterative solver strategies](@ref)
-                       """    
+                       """
 const rlxsolverparams= """
                        - `precond`: One of the [Relaxation strategies](@ref) seen as preconditioner
                        - `solver`: One of the [Iterative solver strategies](@ref)
-                       """    
+                       """
 
 #################################################################################################
 # AMG Solver
@@ -153,7 +153,7 @@ $(rlxsolverparams)
 """
 function RLXSolverAlgorithm end
 
-    
+
 #################################################################################################
 # AMG Preconditioner
 
@@ -196,7 +196,7 @@ Preconditioner strategy (e.g. for the new `precs` kwarg in LinearSolve) for inte
 Fields (for documentation, see [`AMGPrecon`](@ref)):
 $(TYPEDFIELDS)
 """
-Base.@kwdef struct AMGPreconditioner
+Base.@kwdef struct AMGPreconBuilder
     param = nothing
     verbose::Bool = false
     blocksize::Int = 1
@@ -204,12 +204,12 @@ Base.@kwdef struct AMGPreconditioner
     relax::Union{AbstractRelaxation, NamedTuple} = SPAI0Relaxation()
 end
 
-function (amg::AMGPreconditioner)(A::AbstractSparseMatrix)
+function (amg::AMGPreconBuilder)(A::AbstractSparseMatrix)
     (;param, verbose, blocksize, coarsening, relax)=amg
     AMGPrecon(A; param, verbose, blocksize, coarsening, relax)
 end
 
-(amg::AMGPreconditioner)(A,p)=(amg(A),I)
+(amg::AMGPreconBuilder)(A,p)=(amg(A),I)
 
 #################################################################################################
 # Relaxation Preconditioner
@@ -250,16 +250,16 @@ Fields (for documentation, see [`RLXPrecon`](@ref)):
 
 $(TYPEDFIELDS)
 """
-Base.@kwdef struct RLXPreconditioner
+Base.@kwdef struct RLXPreconBuilder
     param = nothing
     verbose::Bool = false
     blocksize::Int = 1
     precond::Union{AbstractRelaxation, NamedTuple} = ILU0Relaxation()
 end
 
-function (rlx::RLXPreconditioner)(A::AbstractSparseMatrix)
+function (rlx::RLXPreconBuilder)(A::AbstractSparseMatrix)
     (;param, verbose, blocksize, precond)=rlx
     RLXPrecon(A; param, verbose, blocksize, precond)
 end
 
-(rlx::RLXPreconditioner)(A,p)=(rlx(A),I)
+(rlx::RLXPreconBuilder)(A,p)=(rlx(A),I)

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -180,7 +180,7 @@ function tskew(;skew=0.0)
     @show norm(u1 - u2)
     @show abs(stats1.niter-stats2.niter)
     norm(u1 - u2) < 10000 * sqrt(eps(Float64))  && abs(stats1.niter-stats2.niter)<5
-    
+
 end
 
 @testset "skew" begin
@@ -205,7 +205,7 @@ function test_linsolve_rlx(Ti, dim, n, bsize = 1)
     prb=LinearProblem(A,A*u0)
     u=solve(prb,RLXSolverAlgorithm(;
                                    param = (solver = (tol = 1.0e-12, type = "bicgstab"), precond = (type = "ilu0",)),))
-    
+
     @show norm(u0 - u)
     norm(u0 - u) < 10 * sqrt(eps(Float64))
 end
@@ -226,7 +226,7 @@ function test_linsolve_amgprecs(Ti, dim, n, bsize = 1)
     A = dlattice(dim, n; Ti)
     u0 = rand(size(A, 1))
     prb=LinearProblem(A,A*u0)
-    u = solve(prb,KrylovJL_CG(precs=AMGPreconditioner(blocksize = bsize)))
+    u = solve(prb,KrylovJL_CG(precs=AMGPreconBuilder(blocksize = bsize)))
     @show norm(u0 - u)
     norm(u0 - u) < 1000 * sqrt(eps(Float64))
 end
@@ -249,7 +249,7 @@ function test_linsolve_rlxprecs(Ti, dim, n, bsize = 1)
     prb=LinearProblem(A,A*u0)
 
     rlx =
-    u = solve(prb,KrylovJL_CG(precs= RLXPreconditioner(blocksize = bsize, precond=(type="ilu0",))))
+    u = solve(prb,KrylovJL_CG(precs= RLXPreconBuilder(blocksize = bsize, precond=(type="ilu0",))))
     @show norm(u0 - u)
     norm(u0 - u) < 1.0e4 * sqrt(eps(Float64))
 end


### PR DESCRIPTION
Avoids misunderstandings and clarifies the role of these callable objects.